### PR TITLE
Update de.json

### DIFF
--- a/web/locales/de.json
+++ b/web/locales/de.json
@@ -93,7 +93,7 @@
         "consumption": "Verbrauch",
         "cpinfo": "<b>Verbrauch</b> bezieht Importe und Exporte mit ein, <b>Produktion</b> ignoriert sie",
         "selectLanguage": "Sprache auswählen",
-        "lowCarbDescription": "Beinhaltet regenerative Energie and Atomkraft"
+        "lowCarbDescription": "Beinhaltet regenerative Energien and Kernenergie"
     },
     "misc": {
         "maintitle": "CO2-Emissionen des Stromverbrauchs in Echtzeit",
@@ -111,7 +111,7 @@
     "hydro storage": "Pumpspeicher",
     "battery storage": "Batteriespeicher",
     "biomass": "Biomasse",
-    "nuclear": "Atomkraft",
+    "nuclear": "Kernenergie",
     "geothermal": "Geothermie",
     "gas": "Erdgas",
     "coal": "Kohle",
@@ -134,7 +134,7 @@
         "mapArrows-answer": "Die Pfeile zwischen den Regionen zeigen den physischen Stromfluss (Importe und Exporte) der Elektrizität: Je schneller sie blinken, desto stärker ist der grenzüberschreitende Stromaustausch. Der Elektrizitätaustausch ist von großer Bedeutung, da beim Import von Strom bilanziell auch auch die Kohlenstoffemissionen importiert werden.",
         "mapSolarWindButtons-question": "Wofür sind die “Sonne” und “Wind”-Buttons auf der Karte da?",
         "mapSolarWindButtons-answer": "Die Knöpfe aktivieren die Anzeige der Echtzeit-Windgeschwindigkeit und Sonneneinstrahlung, womit das momentane Potenzial von Photovoltaik- und Windenergieanlagen abgeschätzt werden kann. Das tatsächliche Potenzial dieser Anlagen ist von vielen weiteren Faktoren abhängig, daher dient diese Visualisierung als ungefährer Indikator des Potenzials.",
-        "mapNuclearColors-question": "Warum werden Regionen mit Atomkraftwerken auf der Karte grün dargestellt?",
+        "mapNuclearColors-question": "Warum werden Regionen mit Kernkraftwerken auf der Karte grün dargestellt?",
         "mapNuclearColors-answer": "Die Erzeugung von Strom mittels Kernkraft hat eine niedrige Kohlenstoffintensität (<a href=\"https://en.wikipedia.org/wiki/Life-cycle_greenhouse-gas_emissions_of_energy_sources#2014_IPCC.2C_Global_warming_potential_of_selected_electricity_sources\" target=\"_blank\") Quelle</a>). Regionen mit hohem Atomstromanteil werden daher auf der Karte grüner dargestellt. Dies bedeutet aber nicht, dass es keine ökologischen Herausforderungen im Zusammenhang mit der Kernenergie gibt (wie dies auch bei anderen Formen der Energieerzeugung der Fall ist). Diese ökologischen Auswirkungen sind nicht Gegenstand dieser Karte.",
         "mapColorBlind-question": "Ich bin farbenblind. Wie kann ich die Karte lesen?",
         "mapColorBlind-answer": "Die in der Karte angezeigte Farbskala kann geändert werden, indem man die Einstellung “Farbenblind-Modus“ aktiviert. Sie befindet sich unten links im Desktopmodus und im Tab “Über“ bei mobilen Geräten."
@@ -157,7 +157,7 @@
         "consumptionFocus-question": "Warum wird die CO2-Intensität des Stromverbrauchs statt der der Stromproduktion berechnet?",
         "consumptionFocus-answer": "Wir glauben, dass die Bürger für den Strom, den sie verbrauchen, verantwortlich sein sollten und nicht für den Strom, der in dem Bereich produziert wird, in dem sie leben. Darüber hinaus sind wir der Meinung, dass Regionen nicht in der Lage sein sollten, einen geringeren Klimaeinfluss zu \"fälschen\", indem sie die Stromerzeugung in andere Regionen verlagern und dann den Strom aus diesen Gebieten importieren.",
         "renewableLowCarbonDifference-question": "Was ist der Unterschied zwischen \"erneuerbar\" und \"kohlenstoffarm\"?",
-        "renewableLowCarbonDifference-answer": "Erneuerbare Energieerzeugung basiert auf erneuerbaren Energiequellen wie Wind- und Wasserströmung, Sonnenschein und Geothermie. Kohlenstoffarme Energieerzeugung bedeutet, dass die Produktion mit sehr geringen Treibhausgasemissionen verbunden ist, z.B. bei der Atomkraft.",
+        "renewableLowCarbonDifference-answer": "Erneuerbare Energieerzeugung basiert auf erneuerbaren Energiequellen wie Wind- und Wasserströmung, Sonnenschein und Geothermie. Kohlenstoffarme Energieerzeugung bedeutet, dass die Produktion mit sehr geringen Treibhausgasemissionen verbunden ist, z.B. bei der Kernkraft.",
         "importsAndExports-question": "Werden Stromimporte und -exporte berücksichtigt?",
         "importsAndExports-answer": "Ja, diese berücksichtigen wir. Importe und Exporte werden auf der Karte als kleine Pfeile zwischen verschiedenen Regionen angezeigt [Link zur Erklärung der Pfeile]. Detaillierte Informationen finden Sie in den angezeigten Grafiken, wenn Sie auf einen Bereich klicken.",
         "emissionsOfStored-question": "Was ist mit den Emissionen der Stromerzeugung, die in Batterien gespeichert oder zum Füllen von Pumpspeicher-Reservoirs verwendet wird?",


### PR DESCRIPTION
- replaced "Atomkraft" with the more correct term "Kernenergie"
- fixed older typo "aus regenerativen Energie"n"